### PR TITLE
api: allow to authenticate through swagger openapi page

### DIFF
--- a/src/slurm_monitor/api/v2/router.py
+++ b/src/slurm_monitor/api/v2/router.py
@@ -1,4 +1,3 @@
-from fastapi import FastAPI
 
 from . import routes
 
@@ -8,11 +7,16 @@ from . import cluster # noqa
 from . import nodes   # noqa
 from . import jobs    # noqa
 
-app = FastAPI(root_path="/api/v2")
+from slurm_monitor.utils.api import createFastAPI
+
+app = createFastAPI(
+        title="slurm-monitor REST API",
+        version="2",
+        root_path="/api/v2"
+      )
 
 @app.get("/")
 async def hello():
     return {"message": "Slurm Monitor API v2"}
-
 
 app.include_router(routes.api_router)

--- a/src/slurm_monitor/utils/api.py
+++ b/src/slurm_monitor/utils/api.py
@@ -1,4 +1,65 @@
+import fastapi
 from fastapi import FastAPI
+
+from slurm_monitor.app_settings import AppSettings
+
+# see https://fastapi.tiangolo.com/how-to/extending-openapi
+def createFastAPI(**kwargs):
+    title = "slurm-monitor"
+    if "title" in kwargs:
+        title = kwargs["title"]
+    else:
+        kwargs["title"] = title
+
+    version="0.3.0"
+    if "version" in kwargs:
+        version = kwargs["version"]
+    else:
+        kwargs["version"] = version
+
+    root_path = "/"
+    if "root_path" in kwargs:
+        root_path = kwargs["root_path"]
+
+    app = FastAPI(
+        **kwargs
+    )
+
+    app_settings = AppSettings.initialize(db_schema_version="v2")
+    def custom_openapi():
+        if app.openapi_schema:
+            return app.openapi_schema
+
+        openapi_schema = fastapi.openapi.utils.get_openapi(
+            title=title,
+            version=version,
+            routes=app.routes,
+        )
+
+        openapi_schema["servers"] = [{ 'url': root_path}]
+
+        if app_settings.oauth.required:
+            app.openapi_schema = openapi_schema
+            if "components" not in openapi_schema:
+                openapi_schema["components"] = {}
+
+            openapi_schema["components"]["securitySchemes"] = {
+                "BearerAuth": {
+                    # https://fastapi.tiangolo.com/reference/openapi/models/?h=securityschemetype#fastapi.openapi.models.SecuritySchemeType
+                    "type": "http",
+                    # https://fastapi.tiangolo.com/reference/openapi/models/?h=securityschemetype#fastapi.openapi.models.HTTPBearer
+                    "scheme": "bearer",
+                    "bearerFormat": "JWT",
+                }
+            }
+
+            openapi_schema["security"] = [{"BearerAuth": []}]
+        app.openapi_schema = openapi_schema
+        return app.openapi_schema
+
+    app.openapi = custom_openapi
+    return app
+
 
 def find_endpoint_by_name(app: FastAPI, name: str, prefix: str = "api/v2"):
     router = [x for x in app.routes if x.name == prefix][0]

--- a/src/slurm_monitor/v2.py
+++ b/src/slurm_monitor/v2.py
@@ -22,6 +22,7 @@ from slurm_monitor.app_settings import AppSettings
 from slurm_monitor.db_operations import DBManager
 from slurm_monitor.api.v2.router import app as api_v2_app
 from slurm_monitor.utils.api import find_endpoint_by_name
+from slurm_monitor.utils.api import createFastAPI
 
 import logging
 from logging import getLogger
@@ -90,11 +91,10 @@ tags_metadata = [
     },
 ]
 
-app = FastAPI(
-    title="slurm-monitor", description="slurm monitor", version="0.2", lifespan=lifespan,
-    openapi_tags=tags_metadata
-)
-
+app = createFastAPI(
+        lifespan=lifespan,
+        openapi_tags=tags_metadata,
+      )
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
These changes introduce an 'Authorize' button on the the api/v2/docs page (only available when oauth is required).
There one can add the Bearer token which is then used when using "Try execute" on the endpoints.