### PR TITLE
Fix #103/listener

### DIFF
--- a/src/slurm_monitor/db/v2/message_subscriber.py
+++ b/src/slurm_monitor/db/v2/message_subscriber.py
@@ -603,6 +603,14 @@ class MessageSubscriber:
                         logger.info(f"Message: {msg}")
 
 
+                    # If a sample arrives there should be no duplicates in the database - an exception is the initialization
+                    # where historic records are retrieved
+                    # Default: allow to update / merge existing information
+                    update = sonar.TopicType.infer(topic) != sonar.TopicType.sample
+                    logger.debug(f"DB insert: {topic} {update=} {ignore_integrity_errors=} - start")
+                    await msg_handler.insert(json.loads(msg), update=update, ignore_integrity_errors=ignore_integrity_errors)
+                    logger.debug(f"DB insert: {topic} - completed")
+
                     # Make the alignment of cluster information from jobs data only when all subsequent job samples have been received
                     # e.g. during INITIALIZATION a number of subsequent job data will be processed - align once all have been
                     # processed
@@ -613,16 +621,8 @@ class MessageSubscriber:
                         logging.info("Auto update - aligning cluster information from jobs data - completed")
                         autoupdate_timestamp = utcnow()
 
-                    # If a sample arrives there should be no duplicates in the database - an exception is the initialization
-                    # where historic records are retrieved
-                    # Default: allow to update / merge existing information
-                    update = sonar.TopicType.infer(topic) != sonar.TopicType.sample
-                    logger.debug(f"DB insert: {topic} {update=} {ignore_integrity_errors=} - start")
-                    await msg_handler.insert(json.loads(msg), update=update, ignore_integrity_errors=ignore_integrity_errors)
-                    logger.debug(f"DB insert: {topic} - completed")
-
                     if sonar.TopicType.infer(topic) == sonar.TopicType.job:
-                        autoupdate_timestamp = None # requires an update
+                        autoupdate_timestamp = None # requires an update when processing the next message that is not a job message
 
                     now = utcnow()
                     seconds_from_now = (now.timestamp() - consumer_record.timestamp/1000.0)
@@ -636,7 +636,6 @@ class MessageSubscriber:
 
                     self.output.next_stats_update = self.stats_interval_in_s - (dt.datetime.now(dt.timezone.utc) - interval_start_time).total_seconds()
                     if (dt.datetime.now(dt.timezone.utc) - interval_start_time).total_seconds() > self.stats_interval_in_s:
-                        requires_autoupdate = False
                         interval_start_time = dt.datetime.now(dt.timezone.utc)
 
                         msg_timestamps = msg_handler.last_msg_per_node

--- a/src/slurm_monitor/db/v2/sonar.py
+++ b/src/slurm_monitor/db/v2/sonar.py
@@ -51,15 +51,8 @@ class Sonar:
             elif len(range_expr) == 2:
                 start, end = range_expr
                 pattern_length = len(start)
-                if not pattern_length == len(end):
-                    raise ValueError("Pattern length of range does not match: "
-                                     f"from {pattern_length} - {len(end)}"
-                    )
 
-                use_zfill = False
-                if start.startswith("0"):
-                    use_zfill = True
-
+                use_zfill = (pattern_length == len(end)) and start.startswith("0")
                 for i in range(int(start), int(end)+1):
                     number = i
                     if use_zfill:

--- a/tests/slurm_monitor/data/sonar/4+cluster.fox.educloud.no.json
+++ b/tests/slurm_monitor/data/sonar/4+cluster.fox.educloud.no.json
@@ -1,0 +1,185 @@
+{
+  "meta": {
+    "producer": "sonar",
+    "version": "0.18.2"
+  },
+  "data": {
+    "type": "cluster",
+    "attributes": {
+      "cluster": "fox.educloud.no",
+      "time": "2026-03-27T14:23:06+01:00",
+      "slurm": true,
+      "partitions": [
+        {
+          "name": "normal",
+          "nodes": [
+            "c1-[5-28]"
+          ]
+        },
+        {
+          "name": "accel",
+          "nodes": [
+            "gpu-[1-2,4-5,7-9,11-17]"
+          ]
+        },
+        {
+          "name": "accel_long",
+          "nodes": [
+            "gpu-[1-2,8-9]"
+          ]
+        },
+        {
+          "name": "mig",
+          "nodes": [
+            "gpu-10"
+          ]
+        },
+        {
+          "name": "autotekst",
+          "nodes": [
+            "gpu-[10,13]"
+          ]
+        },
+        {
+          "name": "bigmem",
+          "nodes": [
+            "bigmem-[1-2]",
+            "c1-29"
+          ]
+        },
+        {
+          "name": "dgx_spark",
+          "nodes": [
+            "dgx-[1-2]"
+          ]
+        },
+        {
+          "name": "ifi_accel",
+          "nodes": [
+            "gpu-[4-6,11-12]"
+          ]
+        },
+        {
+          "name": "ifi_bigmem",
+          "nodes": [
+            "c1-29"
+          ]
+        },
+        {
+          "name": "pods",
+          "nodes": [
+            "c1-[6-7]"
+          ]
+        },
+        {
+          "name": "fhi_bigmem",
+          "nodes": [
+            "bigmem-[1-2]"
+          ]
+        },
+        {
+          "name": "hf_accel",
+          "nodes": [
+            "gpu-[14-15]"
+          ]
+        },
+        {
+          "name": "klm_accel",
+          "nodes": [
+            "gpu-16"
+          ]
+        }
+      ],
+      "nodes": [
+        {
+          "names": [
+            "bigmem-1",
+            "c1-[5,8,10-13,16,21-22,24-28]",
+            "gpu-[1-2,8-10,13-14]"
+          ],
+          "states": [
+            "MIXED",
+            "PLANNED"
+          ]
+        },
+        {
+          "names": [
+            "c1-6"
+          ],
+          "states": [
+            "IDLE",
+            "DRAIN"
+          ]
+        },
+        {
+          "names": [
+            "bigmem-2",
+            "c1-[7,9,14-15,17-20,23]"
+          ],
+          "states": [
+            "ALLOCATED"
+          ]
+        },
+        {
+          "names": [
+            "gpu-7"
+          ],
+          "states": [
+            "MIXED",
+            "RESERVED",
+            "PLANNED"
+          ]
+        },
+        {
+          "names": [
+            "gpu-4"
+          ],
+          "states": [
+            "MIXED",
+            "RESERVED"
+          ]
+        },
+        {
+          "names": [
+            "gpu-[5,12,15-16]"
+          ],
+          "states": [
+            "MIXED"
+          ]
+        },
+        {
+          "names": [
+            "c1-29",
+            "gpu-[6,11,17]"
+          ],
+          "states": [
+            "IDLE"
+          ]
+        },
+        {
+          "names": [
+            "dgx-1"
+          ],
+          "states": [
+            "DOWN",
+            "DRAIN",
+            "MAINTENANCE",
+            "RESERVED",
+            "NOT_RESPONDING"
+          ]
+        },
+        {
+          "names": [
+            "dgx-2"
+          ],
+          "states": [
+            "DOWN",
+            "MAINTENANCE",
+            "RESERVED",
+            "NOT_RESPONDING"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/slurm_monitor/db/v2/test_message_subscriber.py
+++ b/tests/slurm_monitor/db/v2/test_message_subscriber.py
@@ -37,10 +37,15 @@ def test_MessageSubscriber_extract_offset_bounds(txt,
 @pytest.mark.asyncio(loop_scope="function")
 @pytest.mark.parametrize("sonar_msg_files, expected_clusters",
     [
-        [ ["0+job-srl-login3.ex3.simula.no.json"], {"ex3.simula.no": {"nodes": ['h001', 'n004', 'g001'], "partitions": ['dgx2q', 'habanaq', 'hgx2q', 'mi100q'] }}]
+        [ ["0+job-srl-login3.ex3.simula.no.json"], {"ex3.simula.no": {"nodes": ['h001', 'n004', 'g001'], "partitions": ['dgx2q', 'habanaq', 'hgx2q', 'mi100q'] }}],
+        [ ["4+cluster.fox.educloud.no.json"], {
+              "fox.educloud.no": {
+                'partitions': ['normal', 'hf_accel', 'bigmem', 'ifi_accel', 'fhi_bigmem', 'ifi_bigmem', 'autotekst', 'accel_long', 'accel', 'pods', 'dgx_spark', 'klm_accel', 'mig'],
+                'nodes': ['c1-10', 'c1-16', 'c1-25', 'c1-21', 'gpu-10', 'gpu-12', 'gpu-6', 'gpu-17', 'c1-7', 'c1-27', 'c1-8', 'c1-12', 'gpu-13', 'gpu-7', 'dgx-1', 'c1-9', 'c1-20', 'c1-22', 'gpu-8', 'gpu-16', 'gpu-1', 'c1-5', 'c1-6', 'c1-28', 'c1-18', 'gpu-9', 'c1-11', 'c1-26', 'c1-23', 'gpu-4', 'c1-15', 'gpu-11', 'c1-14', 'c1-19', 'c1-17', 'dgx-2', 'c1-29', 'gpu-14', 'c1-24', 'gpu-5', 'bigmem-2', 'bigmem-1', 'gpu-2', 'gpu-15', 'c1-13']
+            }}],
     ]
 )
-async def test_MessageSubcriber_sonar_examples(sonar_msg_files,
+async def test_MessageSubscriber_sonar_examples(sonar_msg_files,
                                              expected_clusters,
                                              test_db_v2__function_scope,
                                              db_config,
@@ -135,9 +140,9 @@ async def test_MessageSubcriber_sonar_examples(sonar_msg_files,
 
     for cluster_name, nodes in expected_clusters.items():
         with db.make_session() as session:
-            results = session.execute(sqlalchemy.text(f"SELECT cluster, nodes, partitions from cluster_attributes where cluster = '{cluster_name}'")).all()
+            results = session.execute(sqlalchemy.text(f"SELECT cluster, nodes, partitions, time from cluster_attributes where cluster = '{cluster_name}' ORDER BY time DESC")).all()
             assert results
-            cluster, nodes, partitions = results[0]
+            cluster, nodes, partitions, time = results[0]
             expected_nodes = expected_clusters[cluster_name]['nodes']
             expected_partitions = expected_clusters[cluster_name]['partitions']
 

--- a/tests/slurm_monitor/db/v2/test_sonar.py
+++ b/tests/slurm_monitor/db/v2/test_sonar.py
@@ -18,7 +18,14 @@ from slurm_monitor.db.v2.sonar import Sonar
         ],
         [" n001 , n007 ,n[098-100]",
          ["n001","n007", "n098", "n099", "n100"]
-        ]
+        ],
+        ["gpu-[1-2,8-10,99-101]",
+         [
+          "gpu-1", "gpu-2",
+          "gpu-8", "gpu-9", "gpu-10",
+          "gpu-99", "gpu-100", "gpu-101"
+         ]
+        ],
     ]
 )
 def test_expand_hostname_range(expression, expected_nodes):


### PR DESCRIPTION
- fixes hostname processing for the default case g[8-10], which requires no filling with zeros g[8-10]
- ensure that autoupdate / sync from incoming job messages runs after handling a cluster message 

fix #103 